### PR TITLE
Add pronoun field to ConjugationResult

### DIFF
--- a/src/conjugation.ts
+++ b/src/conjugation.ts
@@ -119,9 +119,6 @@ function convertParadigmToForm(tense: string): Form {
 }
 
 function convertParadigmToConjugationResults(paradigm: string, data: []): Array<ConjugationResult> {
-    // data.forEach((item: any) => {
-    //     console.log(item.pronoun);
-    // });
     return data.map((item: any) => ({
         pronoun: item.pronoun,
         person: convertPronounToPerson(item.pronoun),

--- a/src/conjugation.ts
+++ b/src/conjugation.ts
@@ -2,6 +2,7 @@ import { Person, CNumber, Tense, Mood, Form } from './constants';
 import { extractComponentData } from './util';
 
 export interface ConjugationResult {
+    pronoun?: string;
     person?: Person;
     number?: CNumber;
     tense: Tense;
@@ -118,7 +119,11 @@ function convertParadigmToForm(tense: string): Form {
 }
 
 function convertParadigmToConjugationResults(paradigm: string, data: []): Array<ConjugationResult> {
+    // data.forEach((item: any) => {
+    //     console.log(item.pronoun);
+    // });
     return data.map((item: any) => ({
+        pronoun: item.pronoun,
         person: convertPronounToPerson(item.pronoun),
         number: convertPronounToNumber(item.pronoun),
         tense: convertParadigmToTense(paradigm),

--- a/src/test/conjugation.test.js
+++ b/src/test/conjugation.test.js
@@ -6,7 +6,13 @@ import request from '../request';
 test('Spanish verb - hacer', () => {
     const html = fs.readFileSync('./src/test/conjug_hacer.html', 'utf-8');
     const result = extract(html);
+    result.forEach(item => {
+        if(item.word === 'estaríamos haciendo') {
+            console.log(item);
+        }
+    });
     expect(result).toContainEqual({
+        pronoun: 'yo',
         person: Person.First,
         number: CNumber.Singular,
         tense: Tense.Present,
@@ -15,7 +21,9 @@ test('Spanish verb - hacer', () => {
         paradigm: 'presentIndicative',
         word: 'hago'
     });
+
     expect(result).toContainEqual({
+        pronoun: 'tú',
         person: Person.Second,
         number: CNumber.Singular,
         tense: Tense.Imperfect2,
@@ -25,6 +33,7 @@ test('Spanish verb - hacer', () => {
         word: 'hicieses'
     });
     expect(result).toContainEqual({
+        pronoun: 'Uds.',
         person: Person.Third,
         number: CNumber.Plural,
         tense: Tense.Negative,
@@ -34,6 +43,7 @@ test('Spanish verb - hacer', () => {
         word: 'no hagan'
     });
     expect(result).toContainEqual({
+        pronoun: 'nosotros',
         person: Person.First,
         number: CNumber.Plural,
         tense: Tense.Conditional,
@@ -43,6 +53,7 @@ test('Spanish verb - hacer', () => {
         word: 'estaríamos haciendo'
     });
     expect(result).toContainEqual({
+        pronoun: 'tú',
         person: Person.Second,
         number: CNumber.Singular,
         tense: Tense.Past,
@@ -57,6 +68,7 @@ test('Real-world verb conjugation - hacer', async () => {
     // Similar test but this one queries the word from SpanishDict.com
     const result = extract(await request.conjugate('hacer'));
     expect(result).toContainEqual({
+        pronoun: 'yo',
         person: Person.First,
         number: CNumber.Singular,
         tense: Tense.Present,
@@ -76,6 +88,7 @@ test('Spanish verb (non-inifinivo) - como', () => {
     const html = fs.readFileSync('./src/test/conjug_como.html', 'utf-8');
     const result = extract(html);
     expect(result).toContainEqual({
+        pronoun: 'él/ella/Ud.',
         person: Person.Third,
         number: CNumber.Singular,
         tense: Tense.Present,

--- a/src/test/conjugation.test.js
+++ b/src/test/conjugation.test.js
@@ -6,11 +6,7 @@ import request from '../request';
 test('Spanish verb - hacer', () => {
     const html = fs.readFileSync('./src/test/conjug_hacer.html', 'utf-8');
     const result = extract(html);
-    result.forEach(item => {
-        if(item.word === 'estaríamos haciendo') {
-            console.log(item);
-        }
-    });
+
     expect(result).toContainEqual({
         pronoun: 'yo',
         person: Person.First,


### PR DESCRIPTION
First off, I want to say that I really love this project! It was the only spanishDictionary conjugation scraper that I actually found to work. 

One feature that I found that I needed, however, was the actual pronoun of the conjugated verb, since I am using this to make conjugation flashcards.

 I went ahead and added some code to do this myself. If you could give this a read over that would be great. I'm not a professional developer and need all of the feedback I can get!