### PR TITLE
Support new 'informal future' tense

### DIFF
--- a/src/conjugation.ts
+++ b/src/conjugation.ts
@@ -82,6 +82,8 @@ function convertParadigmToTense(tense: string): Tense {
             return Tense.Imperfect2;
         case 'future':
             return Tense.Future;
+        case 'informal':
+            return Tense.Informal;
         case 'imperative':
             return Tense.Affirmative;
         case 'negative':

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ enum Tense {
     Conditional = 'conditional',
     Imperfect2 = 'imperfect2',
     Future = 'future',
+    Informal = 'informal',
     Affirmative = 'affirmative',
     Negative = 'negative',
     Past = 'past'


### PR DESCRIPTION
SpanishDict recently added new 'Informal Future' section on the conjugation page, which made `sd-conjugate` script fail with the following stack trace:

```
Caught an error Error: Unknown tense informal
    at convertParadigmToTense (/Users/levkhotov/github/spanish-dict-api/lib/conjugation.js:81:11)
    at /Users/levkhotov/github/spanish-dict-api/lib/conjugation.js:110:16
    at Array.map (<anonymous>)
    at convertParadigmToConjugationResults (/Users/levkhotov/github/spanish-dict-api/lib/conjugation.js:106:17)
    at extract (/Users/levkhotov/github/spanish-dict-api/lib/conjugation.js:129:34)
    at conjugate (/Users/levkhotov/github/spanish-dict-api/lib/index.js:8:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This PR fixes it.